### PR TITLE
Reject year 0 for Hebrew, French and Islamic calendars

### DIFF
--- a/lib/calendars.ml
+++ b/lib/calendars.ml
@@ -553,12 +553,15 @@ let make :
           ~error:(Fun.const @@ check_greg ())
           (check_year (fun () -> year < -45))
     | Hebrew ->
+        check_year (fun () -> year > 0) >>= fun () ->
         check_month (fun () -> month <= 13) >>= fun () ->
         check_day (fun () -> day <= hebrew_nb_days_upper_bound.(month - 1))
     | French ->
+        check_year (fun () -> year > 0) >>= fun () ->
         check_month (fun () -> month <= 13) >>= fun () ->
         check_day (fun () -> day <= 30)
     | Islamic ->
+        check_year (fun () -> year > 0) >>= fun () ->
         check_month (fun () -> month <= 12) >>= fun () ->
         check_day (fun () -> day <= 30)
   in


### PR DESCRIPTION
These calendars have no year zero. Previously, year=0 passed validation and produced incorrect conversions (e.g. Hebrew d=0,m=0,y=0 mapped to d=1,m=1,y=2). Add check_year year>0 for all three calendar kinds in make.

Fixes geneweb/geneweb#160